### PR TITLE
Fix bug with Bridge Object

### DIFF
--- a/Objects/Bridge/Bridge.asm
+++ b/Objects/Bridge/Bridge.asm
@@ -91,10 +91,16 @@ sub_387B6:															; check bridge explosion
 		beq.s	sub_387E0											; bridge not explode
 
 loc_387BE:
-		move.l	#loc_3890C,address(a0)								; bridge explode
-;		move.b	#$E,objoff_34(a0)							; this line causes issues when creating an exploding bridge larger than the default
 		move.l	#loc_388E4,d4
-		bra.w	sub_389C8
+		bsr.w	sub_389C8
+
+		; set wait
+		move.b	#$E,Obj_Bridge_child2(a0)
+
+		; next
+		lea	loc_3890C(pc),a1										; bridge explode
+		move.l	a1,address(a0)
+		jmp		(a1)
 
 ; =============== S U B R O U T I N E =======================================
 

--- a/Objects/Bridge/Bridge.asm
+++ b/Objects/Bridge/Bridge.asm
@@ -92,7 +92,7 @@ sub_387B6:															; check bridge explosion
 
 loc_387BE:
 		move.l	#loc_3890C,address(a0)								; bridge explode
-		move.b	#$E,objoff_34(a0)
+;		move.b	#$E,objoff_34(a0)							; this line causes issues when creating an exploding bridge larger than the default
 		move.l	#loc_388E4,d4
 		bra.w	sub_389C8
 


### PR DESCRIPTION
When creating an exploding bridge object larger than the default 8 segments this line causes issues.

While testing on the S.C.E Extended branch the game was crashing when the explosion triggered. On S1 S.C.E the second child object wouldn't be processed properly and the bridge segments don't explode.

Removing this line fixes the issue, the code under sub_389C8 is designed to process the additional child object segments without issue.